### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ This is part of the MCP track for the Hackathon (with a smidge of Agents)
 
 ❤️ **A very big thank you to the sponsors for the generous credits for this hackathon and Hugging Face and Gradio for putting this event together** 🔥
 
+<a href="https://glama.ai/mcp/servers/@CodeHalwell/gradio-mcp-agent-hack">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@CodeHalwell/gradio-mcp-agent-hack/badge" alt="Hub MCP server" />
+</a>
 
 **Special thanks to Yuvi for putting up with us in the Discord asking for credits 😂**
 


### PR DESCRIPTION
This PR adds a badge for the [MCP Hub](https://glama.ai/mcp/servers/@CodeHalwell/gradio-mcp-agent-hack) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@CodeHalwell/gradio-mcp-agent-hack">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@CodeHalwell/gradio-mcp-agent-hack/badge" alt="Hub MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.